### PR TITLE
Fix `typeNum` GET-parameter (Fix #6)

### DIFF
--- a/Classes/Utility/UriBuilder.php
+++ b/Classes/Utility/UriBuilder.php
@@ -120,6 +120,12 @@ abstract class UriBuilder
             $uri .= $prefix . http_build_query([self::getNamespace() => $argumentsToRestore]);
         }
 
+        // If the `typeNum` is part of the arguments array, append the `type` parameter to the URI
+        if (isset($arguments['type']) && $arguments['type'] === self::PAGE_TYPE) {
+            $prefix = mb_strpos($uri, '?') === false ? '?' : '&';
+            $uri .= $prefix . 'type=' . self::PAGE_TYPE;
+        }
+
         return $uri;
     }
 


### PR DESCRIPTION
If `typeNum` is in arguments array, append the `type` parameter to the URI (Fix #6)

This change tries to apply a fix for the problem without the need to change anything in the calling function.

Please feel free to reject it, if you don't think it's a good solution.